### PR TITLE
fix: remove unused imports in admin cookie page

### DIFF
--- a/frontend/src/app/admin/cookie/page.tsx
+++ b/frontend/src/app/admin/cookie/page.tsx
@@ -1,11 +1,6 @@
 'use client';
 
 import { useEffect, useState, useRef } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Separator } from '@/components/ui/separator';
 import {
   Upload,
   FileText,
@@ -14,11 +9,7 @@ import {
   AlertCircle,
   Trash2,
   TestTube,
-  RefreshCw,
-  Cookie,
-  CloudUpload,
-  FileCheck,
-  Clock
+  RefreshCw
 } from 'lucide-react';
 import { toast } from 'sonner';
 


### PR DESCRIPTION
- Remove unused shadcn UI component imports that were causing build errors
- Keep only the imports that are actually used in the component
- Fix ESLint warnings to ensure successful Docker build